### PR TITLE
oled mode switch

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewFeedActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewFeedActivity.java
@@ -16,6 +16,7 @@ import android.util.Log;
 import android.util.Xml;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
@@ -82,7 +83,18 @@ public class NewFeedActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_new_feed);
 
+        ViewGroup rootView = (ViewGroup) ((ViewGroup) this
+                .findViewById(android.R.id.content)).getChildAt(0);
+        if(ThemeChooser.getInstance(this).isDarkTheme(this)) {
+            if(ThemeChooser.getInstance(this).isOledMode(this, false)) {
+                rootView.setBackgroundResource(R.color.rssItemListBackgroundOled);
+            } else {
+                rootView.setBackgroundResource(R.color.rssItemListBackground);
+            }
+        }
+
         ButterKnife.bind(this);
+
 
         if (toolbar != null) {
             setSupportActionBar(toolbar);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewFeedActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewFeedActivity.java
@@ -16,7 +16,6 @@ import android.util.Log;
 import android.util.Xml;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
@@ -82,16 +81,6 @@ public class NewFeedActivity extends AppCompatActivity {
         ThemeChooser.ChooseTheme(this);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_new_feed);
-
-        ViewGroup rootView = (ViewGroup) ((ViewGroup) this
-                .findViewById(android.R.id.content)).getChildAt(0);
-        if(ThemeChooser.getInstance(this).isDarkTheme(this)) {
-            if(ThemeChooser.getInstance(this).isOledMode(this, false)) {
-                rootView.setBackgroundResource(R.color.rssItemListBackgroundOled);
-            } else {
-                rootView.setBackgroundResource(R.color.rssItemListBackground);
-            }
-        }
 
         ButterKnife.bind(this);
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
@@ -64,6 +64,7 @@ import de.luhmer.owncloudnewsreader.database.model.RssItem;
 import de.luhmer.owncloudnewsreader.database.model.RssItemDao;
 import de.luhmer.owncloudnewsreader.helper.AsyncTaskHelper;
 import de.luhmer.owncloudnewsreader.helper.Search;
+import de.luhmer.owncloudnewsreader.helper.ThemeChooser;
 import io.reactivex.observers.DisposableObserver;
 
 /**
@@ -380,7 +381,17 @@ public class NewsReaderDetailFragment extends Fragment {
 	public View onCreateView(LayoutInflater inflater, ViewGroup container,
 			Bundle savedInstanceState) {
 		View rootView = inflater.inflate(R.layout.fragment_newsreader_detail, container, false);
+
+		if(ThemeChooser.getInstance(getActivity()).isDarkTheme(rootView.getContext())) {
+            if(ThemeChooser.getInstance(getActivity()).isOledMode(rootView.getContext(), false)) {
+                rootView.setBackgroundResource(R.color.rssItemListBackgroundOled);
+            } else {
+                rootView.setBackgroundResource(R.color.rssItemListBackground);
+            }
+        }
+
         ButterKnife.bind(this, rootView);
+
 
         recyclerView.setHasFixedSize(true);
 		recyclerView.setLayoutManager(new LinearLayoutManager(getActivity(), LinearLayoutManager.VERTICAL, false));

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
@@ -64,7 +64,6 @@ import de.luhmer.owncloudnewsreader.database.model.RssItem;
 import de.luhmer.owncloudnewsreader.database.model.RssItemDao;
 import de.luhmer.owncloudnewsreader.helper.AsyncTaskHelper;
 import de.luhmer.owncloudnewsreader.helper.Search;
-import de.luhmer.owncloudnewsreader.helper.ThemeChooser;
 import io.reactivex.observers.DisposableObserver;
 
 /**
@@ -382,15 +381,7 @@ public class NewsReaderDetailFragment extends Fragment {
 			Bundle savedInstanceState) {
 		View rootView = inflater.inflate(R.layout.fragment_newsreader_detail, container, false);
 
-		if(ThemeChooser.getInstance(getActivity()).isDarkTheme(rootView.getContext())) {
-            if(ThemeChooser.getInstance(getActivity()).isOledMode(rootView.getContext(), false)) {
-                rootView.setBackgroundResource(R.color.rssItemListBackgroundOled);
-            } else {
-                rootView.setBackgroundResource(R.color.rssItemListBackground);
-            }
-        }
-
-        ButterKnife.bind(this, rootView);
+		ButterKnife.bind(this, rootView);
 
 
         recyclerView.setHasFixedSize(true);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
@@ -30,6 +30,7 @@ import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
@@ -52,6 +53,7 @@ import android.support.v7.widget.AppCompatRadioButton;
 import android.support.v7.widget.AppCompatSpinner;
 import android.support.v7.widget.Toolbar;
 import android.util.AttributeSet;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -153,11 +155,11 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             getSupportActionBar().setTitle(R.string.title_activity_settings);
         }
 
-		if(ThemeChooser.getInstance(this).isOledMode(this, false)) {
-            getWindow().getDecorView().setBackgroundResource(R.color.rssItemListBackgroundOled);
-		} else {
-            getWindow().getDecorView().setBackgroundResource(R.color.rssItemListBackground);
-        }
+        TypedValue typedValue = new TypedValue();
+        Resources.Theme theme = getTheme();
+        theme.resolveAttribute(R.attr.rssItemListBackground, typedValue, true);
+        int color = typedValue.data;
+        getWindow().getDecorView().setBackgroundColor(color);
     }
 
 	@Override

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/SettingsActivity.java
@@ -30,7 +30,6 @@ import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
 import android.content.Intent;
 import android.content.res.Configuration;
-import android.content.res.Resources;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
@@ -53,7 +52,6 @@ import android.support.v7.widget.AppCompatRadioButton;
 import android.support.v7.widget.AppCompatSpinner;
 import android.support.v7.widget.Toolbar;
 import android.util.AttributeSet;
-import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -110,7 +108,9 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
     public static final String PREF_SYNC_SETTINGS = "pref_sync_settings";
 
     public static final String SP_APP_THEME = "sp_app_theme";
-    public static final String SP_FEED_LIST_LAYOUT = "sp_feed_list_layout";
+	public static final String CB_OLED_MODE = "cb_oled_mode";
+
+	public static final String SP_FEED_LIST_LAYOUT = "sp_feed_list_layout";
     public static final String CACHE_CLEARED = "CACHE_CLEARED";
     public static final String SP_MAX_CACHE_SIZE = "sp_max_cache_size";
     public static final String SP_SORT_ORDER = "sp_sort_order";
@@ -153,12 +153,12 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
             getSupportActionBar().setTitle(R.string.title_activity_settings);
         }
 
-		TypedValue typedValue = new TypedValue();
-		Resources.Theme theme = getTheme();
-		theme.resolveAttribute(R.attr.rssItemListBackground, typedValue, true);
-		int color = typedValue.data;
-		getWindow().getDecorView().setBackgroundColor(color);
-	}
+		if(ThemeChooser.getInstance(this).isOledMode(this, false)) {
+            getWindow().getDecorView().setBackgroundResource(R.color.rssItemListBackgroundOled);
+		} else {
+            getWindow().getDecorView().setBackgroundResource(R.color.rssItemListBackground);
+        }
+    }
 
 	@Override
 	protected void onPostCreate(Bundle savedInstanceState) {
@@ -475,12 +475,14 @@ public class SettingsActivity extends AppCompatPreferenceActivity {
 		if(prefFrag != null)
 		{
 			bindPreferenceSummaryToValue(prefFrag.findPreference(SP_APP_THEME));
+            bindPreferenceBooleanToValue(prefFrag.findPreference(CB_OLED_MODE));
 			bindPreferenceSummaryToValue(prefFrag.findPreference(SP_FEED_LIST_LAYOUT));
 			bindPreferenceSummaryToValue(prefFrag.findPreference(SP_DISPLAY_BROWSER));
 		}
 		else
 		{
 			bindPreferenceSummaryToValue(prefAct.findPreference(SP_APP_THEME));
+            bindPreferenceBooleanToValue(prefAct.findPreference(CB_OLED_MODE));
 			bindPreferenceSummaryToValue(prefAct.findPreference(SP_FEED_LIST_LAYOUT));
 			bindPreferenceSummaryToValue(prefAct.findPreference(SP_DISPLAY_BROWSER));
 		}

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/async_tasks/RssItemToHtmlTask.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/async_tasks/RssItemToHtmlTask.java
@@ -102,12 +102,13 @@ public class RssItemToHtmlTask extends AsyncTask<Void, Void, String> {
             case 2: // Dark Theme
                 body_id = "darkTheme";
                 break;
-            case 3: // Dark Theme for OLED
-                body_id = "darkThemeOLED";
-                break;
             default:
                 // this should never happen!
                 body_id = "darkTheme";
+        }
+
+        if(ThemeChooser.getInstance(context).isOledMode(context, false) && ThemeChooser.getInstance(context).isDarkTheme(context)) {
+            body_id = "darkThemeOLED";
         }
 
         boolean isRightToLeft = context.getResources().getBoolean(R.bool.is_right_to_left);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/ThemeChooser.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/ThemeChooser.java
@@ -66,6 +66,13 @@ public class ThemeChooser {
                 // what would be a meaningful default? Auto mode?
                 break;
         }
+
+
+        if(ThemeChooser.getInstance(act).isOledMode(act, false)) {
+            if(ThemeChooser.getInstance(act).isDarkTheme(act)) {
+                act.setTheme(R.style.AppThemeOLED);
+            }
+        }
     }
 
     // Check if the currently loaded theme is different from the one set in the settings, or if OLED mode changed
@@ -78,7 +85,6 @@ public class ThemeChooser {
         switch(AppCompatDelegate.getDefaultNightMode()) {
             case AppCompatDelegate.MODE_NIGHT_YES:
                 return true;
-
             case AppCompatDelegate.MODE_NIGHT_AUTO:
                 int nightModeFlags = context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
                 if(Configuration.UI_MODE_NIGHT_YES == nightModeFlags) {
@@ -92,7 +98,7 @@ public class ThemeChooser {
         }
     }
 
-    public Boolean isOledMode(Context context, boolean forceReloadCache) {
+    public boolean isOledMode(Context context, boolean forceReloadCache) {
         if(mOledMode == null || forceReloadCache) {
             SharedPreferences mPrefs = PreferenceManager.getDefaultSharedPreferences(context);
             mOledMode = mPrefs.getBoolean(SettingsActivity.CB_OLED_MODE, false);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/ThemeChooser.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/helper/ThemeChooser.java
@@ -34,6 +34,7 @@ import de.luhmer.owncloudnewsreader.SettingsActivity;
 public class ThemeChooser {
 
     private Integer mSelectedTheme;
+    private Boolean mOledMode;
     private static ThemeChooser mInstance;
 
     public static ThemeChooser getInstance(Context context) {
@@ -61,16 +62,16 @@ public class ThemeChooser {
                 act.setTheme(R.style.AppTheme);
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
                 break;
-            case 3: // Dark Theme for OLED
-                act.setTheme(R.style.AppThemeOLED);
-                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+            default:
+                // what would be a meaningful default? Auto mode?
                 break;
         }
     }
 
-    // Check if the currently loaded theme is different from the one set in the settings
+    // Check if the currently loaded theme is different from the one set in the settings, or if OLED mode changed
     public boolean themeRequiresRestartOfUI(Context context) {
-        return !mSelectedTheme.equals(getSelectedTheme(context, true));
+        return !mSelectedTheme.equals(getSelectedTheme(context, true)) ||
+               !mOledMode.equals(isOledMode(context, true));
     }
 
     public boolean isDarkTheme(Context context) {
@@ -89,6 +90,14 @@ public class ThemeChooser {
             default:
                 return false;
         }
+    }
+
+    public Boolean isOledMode(Context context, boolean forceReloadCache) {
+        if(mOledMode == null || forceReloadCache) {
+            SharedPreferences mPrefs = PreferenceManager.getDefaultSharedPreferences(context);
+            mOledMode = mPrefs.getBoolean(SettingsActivity.CB_OLED_MODE, false);
+        }
+        return mOledMode;
     }
 
     public Integer getSelectedTheme(Context context, boolean forceReloadCache) {

--- a/News-Android-App/src/main/res/values-night/colors.xml
+++ b/News-Android-App/src/main/res/values-night/colors.xml
@@ -23,7 +23,6 @@
     <color name="colorPrimaryDark">@color/nextcloudBlue</color>
     <color name="colorAccent">#8698af</color>
     <color name="rssItemListBackground">@color/material_grey_900</color>
-    <color name="rssItemListBackgroundOled">@android:color/black</color>
 
 
     <color name="starredColor">@android:color/holo_orange_light</color>

--- a/News-Android-App/src/main/res/values-night/colors.xml
+++ b/News-Android-App/src/main/res/values-night/colors.xml
@@ -23,6 +23,8 @@
     <color name="colorPrimaryDark">@color/nextcloudBlue</color>
     <color name="colorAccent">#8698af</color>
     <color name="rssItemListBackground">@color/material_grey_900</color>
+    <color name="rssItemListBackgroundOled">@android:color/black</color>
+
 
     <color name="starredColor">@android:color/holo_orange_light</color>
     <color name="unstarredColor">#ffcccccc</color>

--- a/News-Android-App/src/main/res/values/colors.xml
+++ b/News-Android-App/src/main/res/values/colors.xml
@@ -29,7 +29,6 @@
     <color name="colorPrimaryDark">@color/nextcloudBlue</color>
     <color name="colorAccent">@color/colorPrimary</color>
     <color name="rssItemListBackground">@android:color/white</color>
-    <color name="rssItemListBackgroundOled">@android:color/white</color>
 
 
     <color name="starredColor">@android:color/holo_orange_light</color>

--- a/News-Android-App/src/main/res/values/colors.xml
+++ b/News-Android-App/src/main/res/values/colors.xml
@@ -29,6 +29,8 @@
     <color name="colorPrimaryDark">@color/nextcloudBlue</color>
     <color name="colorAccent">@color/colorPrimary</color>
     <color name="rssItemListBackground">@android:color/white</color>
+    <color name="rssItemListBackgroundOled">@android:color/white</color>
+
 
     <color name="starredColor">@android:color/holo_orange_light</color>
     <color name="unstarredColor">#ff888888</color>

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -203,21 +203,20 @@
     <string name="pref_display_apptheme_auto">Light / Dark (based on Daytime)</string>
     <string name="pref_display_apptheme_light">Light</string>
     <string name="pref_display_apptheme_dark">Dark</string>
-    <string name="pref_display_apptheme_dark_oled">Dark (for OLED Screens)</string>
 
     <string-array name="pref_display_apptheme" translatable="false">
         <item>@string/pref_display_apptheme_auto</item>
         <item>@string/pref_display_apptheme_light</item>
         <item>@string/pref_display_apptheme_dark</item>
-        <item>@string/pref_display_apptheme_dark_oled</item>
     </string-array>
     <string-array name="pref_display_apptheme_values" translatable="false">
         <item>0</item>
         <item>1</item>
         <item>2</item>
-        <item>3</item>
     </string-array>
 
+    <string name="pref_oled_mode">Black background</string>
+    <string name="pref_oled_mode_summary">For dark theme on OLED screens</string>
 
     <string-array name="pref_title_lines_count" translatable="false">
         <item>1</item>

--- a/News-Android-App/src/main/res/values/themes.xml
+++ b/News-Android-App/src/main/res/values/themes.xml
@@ -3,6 +3,12 @@
 
     <style name="AppTheme" parent="AppTheme.Base"/>
 
+    <style name="AppThemeOLED" parent="AppTheme.Base">
+        <item name="rssItemListBackground">@android:color/black</item>
+        <item name="news_detail_background_color">@android:color/black</item>
+        <item name="primaryTextColor">@android:color/white</item>
+    </style>
+
     <style name="AppTheme.Base" parent="Theme.AppCompat.DayNight">
         <item name="android:windowBackground">@drawable/splash_screen</item>
 

--- a/News-Android-App/src/main/res/values/themes.xml
+++ b/News-Android-App/src/main/res/values/themes.xml
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="AppThemeOLED" parent="AppTheme.Base">
-        <item name="rssItemListBackground">@android:color/black</item>
-        <item name="news_detail_background_color">@android:color/black</item>
-        <item name="primaryTextColor">@android:color/white</item>
-    </style>
-
-
     <style name="AppTheme" parent="AppTheme.Base"/>
 
     <style name="AppTheme.Base" parent="Theme.AppCompat.DayNight">

--- a/News-Android-App/src/main/res/xml/pref_display.xml
+++ b/News-Android-App/src/main/res/xml/pref_display.xml
@@ -12,8 +12,13 @@
         android:entryValues="@array/pref_display_apptheme_values"
         android:key="sp_app_theme"
         android:title="@string/pref_title_app_theme" />
-    
-    
+
+    <SwitchPreference
+        android:key="cb_oled_mode"
+        android:title="@string/pref_oled_mode"
+        android:summary="@string/pref_oled_mode_summary"/>
+
+
     <ListPreference
         android:defaultValue="0"
         android:entries="@array/pref_display_feed_list_layout"


### PR DESCRIPTION
Change set for adding a boolean settings switch for dark theme black background for OLED screens.
The background changing is applied to all non-dialog-like screens:
* news reader list
* settings screen
* add new feed screen

It is *not* applied to any popup-kind of dialogs:
* left sidebar
* settings button menu
* server settings screen
* about/change dialog

It is also not (yet) applied to the built-in webbrowser view for articles.


